### PR TITLE
Don't repeat any enterNode() implementation from FileReflector

### DIFF
--- a/lib/WP/Reflection/FileReflector.php
+++ b/lib/WP/Reflection/FileReflector.php
@@ -10,85 +10,49 @@ use phpDocumentor\Reflection\FileReflector;
  * hooks and note function relationships.
  */
 class WP_Reflection_FileReflector extends FileReflector {
-	/** @var WP_Reflection_HookReflector[] */
+	/**
+	 * List of hooks defined in global scope in this file.
+	 *
+	 * @var WP_Reflection_HookReflector[]
+	 */
 	public $hooks = array();
 
-	/** @var PHPParser_Node[] */
+	/**
+	 * Stack of classes/methods/functions currently being parsed.
+	 *
+	 * @see WP_Reflection_FileReflector::getLocation()
+	 * @var phpDocumentor\Reflection\BaseReflector[]
+	 */
 	protected $location = array();
 
 	public function enterNode(PHPParser_Node $node) {
-		$prettyPrinter = new PHPParser_PrettyPrinter_Zend;
+		parent::enterNode($node);
 
 		switch ($node->getType()) {
-			case 'Stmt_Use':
-				/** @var PHPParser_Node_Stmt_UseUse $use */
-				foreach ($node->uses as $use) {
-					$this->context->setNamespaceAlias(
-						$use->alias,
-						implode('\\', $use->name->parts)
-					);
-				}
-				break;
-			case 'Stmt_Namespace':
-				$this->context->setNamespace(implode('\\', $node->name->parts));
-				break;
+			// Add classes, functions, and methods to the current location stack
 			case 'Stmt_Class':
-				$class = new Reflection\ClassReflector($node, $this->context);
-				array_push($this->location, $class);
-				$class->parseSubElements();
-				$this->classes[] = $class;
-				break;
-			case 'Stmt_Trait':
-				$trait = new Reflection\TraitReflector($node, $this->context);
-				$this->traits[] = $trait;
-				break;
-			case 'Stmt_Interface':
-				$interface = new Reflection\InterfaceReflector($node, $this->context);
-				array_push($this->location, $interface);
-				$interface->parseSubElements();
-				$this->interfaces[] = $interface;
+				array_push($this->location, end($this->classes));
 				break;
 			case 'Stmt_Function':
-				$function = new Reflection\FunctionReflector($node, $this->context);
-				array_push($this->location, $function);
-				$this->functions[] = $function;
-				break;
-			case 'Stmt_Const':
-				foreach ($node->consts as $constant) {
-					$reflector = new Reflection\ConstantReflector(
-						$node,
-						$this->context,
-						$constant
-					);
-					$this->constants[] = $reflector;
-				}
-				break;
-			case 'Expr_FuncCall':
-				if ($node->name instanceof PHPParser_Node_Name && $node->name == 'define') {
-					$name = trim($prettyPrinter->prettyPrintExpr($node->args[0]->value), '\'');
-					$constant = new PHPParser_Node_Const($name, $node->args[1]->value, $node->getAttributes());
-					$constant->namespacedName = new PHPParser_Node_Name(
-						($this->current_namespace ? $this->current_namespace.'\\' : '') . $name
-					);
-
-					$constant_statement = new PHPParser_Node_Stmt_Const(array($constant));
-					$constant_statement->setAttribute('comments', array($node->getDocComment()));
-					$this->constants[] = new Reflection\ConstantReflector($constant_statement, $this->context, $constant);
-				} else if ($this->isFilter($node)) {
-					$hook = new WP_Reflection_HookReflector($node, $this->context);
-					$this->getLocation()->hooks[] = $hook;
-				}
-				break;
-			case 'Expr_Include':
-				$include = new Reflection\IncludeReflector($node, $this->context);
-				$this->includes[] = $include;
+				array_push($this->location, end($this->functions));
 				break;
 			case 'Stmt_ClassMethod':
 				$method = $this->findMethodReflector($this->getLocation(), $node);
-				if ($method)
+				if ($method) {
 					array_push($this->location, $method);
-				else
+				} else {
+					// Repeat the current location so that leaveNode() doesn't
+					// pop it off
 					array_push($this->location, $this->getLocation());
+				}
+				break;
+
+			// Parse out hook definitions and add them to the current location
+			case 'Expr_FuncCall':
+				if ($this->isFilter($node)) {
+					$hook = new WP_Reflection_HookReflector($node, $this->context);
+					$this->getLocation()->hooks[] = $hook;
+				}
 				break;
 		}
 	}


### PR DESCRIPTION
When updating the location stack it's possible to just peek at the end of the appropriate array to get the class/function reflector. Hook parsing can also be done after the original enterNode() has a go since it only relies on the location stack.

Not only is this simpler than using LSEN from the context object (which would require making look ups into the arrays), but the LSEN part of the context object hasn't actually been implemented upstream yet.
