### PR TITLE
Add .gitignore for composer files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/vendor/
-output.json
+composer.phar
+vendor/*


### PR DESCRIPTION
Pull adds a gitignore for the Composer files.

For people new to Composer (i.e. me) who haven't used it before, it's pretty easily to accidentally commit these, and it makes `git status` look messy.
