### PR TITLE
Don't block parsing files inside the wp-content folder

### DIFF
--- a/lib/WP/runner.php
+++ b/lib/WP/runner.php
@@ -13,9 +13,6 @@ function get_wp_files($directory) {
 			if ($file->getFilename() === 'class-wp-json-server.php')
 				continue;
 
-			if (strpos($file->getPath(), 'wp-content') !== false)
-				continue;
-
 			$files[] = $file->getPathname();
 		}
 	}


### PR DESCRIPTION
Currently, WP Parser is meant to be run in the root directory of a
WordPress site to generate documentation for WordPress core, and
therefore ignoring everything in wp-content makes sense. However, this
makes it harder to generate the JSON in a specific directory -- say for
a specific plugin.

One solution is to require people to check out a copy of that plugin
outside a wp-content folder, and run the documentation there. However,
as WP Parser is hopefully going to be used by all great plugins, this
puts a speedbump in the way of the plugin authors.

The onus should be on the person running WP Parser to decide which
directories/files need to be looked at, rather than blocking all
wp-content paths.
