### PR TITLE
Don't append / to the end of a file in the extraction message

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -108,13 +108,13 @@ class Command extends WP_CLI_Command {
 	 * @return string
 	 */
 	protected function _get_phpdoc_data( $path, $format = 'json' ) {
-		WP_CLI::line( sprintf( 'Extracting PHPDoc from %1$s/. This may take a few minutes...', $path ) );
+		$is_file = is_file( $path );
+		WP_CLI::line( sprintf( 'Extracting PHPDoc from %1$s. This may take a few minutes...', $is_file ? "$path/" : $path ) );
 
 		// Find the files to get the PHPDoc data from. $path can either be a folder or an absolute ref to a file.
-		if ( is_file( $path ) ) {
+		if ( $is_file ) {
 			$files = array( $path );
 			$path  = dirname( $path );
-
 		} else {
 			ob_start();
 			$files = get_wp_files( $path );


### PR DESCRIPTION
When importing asingle file, the message will show `file.php/` instead of just `file.php` as it assumes it is a directory.
