### PR TITLE
Retrieve type and variable information from docblock tags

### DIFF
--- a/lib/WP/runner.php
+++ b/lib/WP/runner.php
@@ -109,10 +109,15 @@ function export_docblock($element) {
 		'tags' => array(),
 	);
 	foreach ($docblock->getTags() as $tag) {
-		$output['tags'][] = array(
+		$t = array(
 			'name' => $tag->getName(),
-			'content' => $tag->getContent(),
+			'content' => $tag->getDescription(),
 		);
+		if (method_exists($tag, 'getTypes'))
+			$t['types'] = $tag->getTypes();
+		if (method_exists($tag, 'getVariableName'))
+			$t['variable'] = $tag->getVariableName();
+		$output['tags'][] = $t;
 	}
 
 	return $output;


### PR DESCRIPTION
Make the phpDocumentor libraries do the work of splitting up docblock tags into their component parts.

This simple change adds two new pieces to tag entries: types and variable. For example:

```
@param int|object $post Post ID or object.
```

gives

```
{
  "name": "param",
  "content": "Post ID or object.",                                                                            
  "types": [
    "int",
    "object"
  ],
  "variable": "$post"
},
```

Todo: use this information at the higher levels.

Aims to fix #4 and #5.
