### PR TITLE
Don't let the expand_content filter run recursively

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -134,6 +134,9 @@ function humanize_separator( $type ) {
  */
 function expand_content( $content ) {
 	$post = get_post();
+	
+	// Remove our filter, as we don't want to run again recursively if get_the_content is called
+	remove_filter( 'the_content', __NAMESPACE__ . '\\expand_content' );
 
 	if ( $post->post_type !== 'wpapi-class' && $post->post_type !== 'wpapi-function' )
 		return $content;


### PR DESCRIPTION
If functions don't have doc blocks, there is no excerpt for the function post. wp_trim_excerpt will get called which will go to get_the_content to try to make a custom excerpt, which will call expand_content, which will call wp_trim_excerpt, which will ...
