### PR TITLE
Skip files in the wp-content directory

### DIFF
--- a/lib/WP/runner.php
+++ b/lib/WP/runner.php
@@ -1,13 +1,13 @@
 <?php
 
 function get_wp_files($directory) {
-	$iterableFiles =  new RecursiveIteratorIterator(
+	$iterableFiles = new RecursiveIteratorIterator(
 		new RecursiveDirectoryIterator($directory)
 	);
 	$files = array();
 	try {
 		foreach( $iterableFiles as $file ) {
-			if ($file->getExtension() !== 'php')
+			if ($file->getExtension() !== 'php' || strpos($iterableFiles->getSubPath(), 'wp-content') !== false)
 				continue;
 
 			$files[] = $file->getPathname();


### PR DESCRIPTION
Do we want any documentation to be generated from PHP files in `wp-content`?
