### PR TITLE
Improve CPT registration

### DIFF
--- a/importer.php
+++ b/importer.php
@@ -208,8 +208,11 @@ class Importer {
 		update_post_meta( $class_id, '_wpapi_visibility',        $data['visibility'] );
 
 		// Now add the methods
-		foreach ( $data['methods'] as $method )
+		foreach ( $data['methods'] as $method ) {
+			// Namespace method names with the class name
+			$method['name'] = $data['name'] . '-' . $method['name'];
 			$this->import_item( $method, $class_id, $import_internal );
+		}
 
 		return $class_id;
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -51,6 +51,9 @@ function register_post_types() {
 		'supports' => $supports,
 	) );
 
+	// Methods
+	add_rewrite_rule( 'method/([^/]+)/([^/]+)/?$', 'index.php?post_type=wpapi-function&name=$matches[1]-$matches[2]', 'top' );
+
 	// Classes
 	register_post_type( 'wpapi-class', array(
 		'has_archive' => 'classes',
@@ -111,6 +114,16 @@ function register_taxonomies() {
 		'update_count_callback' => '_update_post_term_count',
 	) );
 }
+
+function method_permalink( $link, $post ) {
+	if ( $post->post_type !== 'wpapi-function' || $post->post_parent == 0 )
+		return $link;
+
+	list( $class, $method ) = explode( '-', $post->post_name );
+	$link = home_url( user_trailingslashit( "method/$class/$method" ) );
+	return $link;
+}
+add_filter( 'post_type_link', __NAMESPACE__ . '\\method_permalink', 10, 2 );
 
 /**
  * Raw phpDoc could potentially introduce unsafe markup into the HTML, so we sanitise it here.


### PR DESCRIPTION
The main aim of this PR was to have working permalinks for methods. I have implemented these as `/method/:class/:method` by namespacing method post_names in the database, e.g. `wp_query-get_posts`. This allows the rewrite rule to just concatenate the two matches into a name to lookup. Link generation simply involves replacing the `-` with a slash. I would've preferred to use `::` as the separator, but this isn't allowed through `sanitize_title()` so I chose a simpler option for now.

The other changes were made to simplify the current CPT registration code by removing unnecessary registration options.
