### PR TITLE
Fix an invalid synopsis warning from wp-cli

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -14,7 +14,7 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Generate a JSON file containing the PHPDoc markup, and save to filesystem.
 	 *
-	 * @synopsis <directory> [<output_file>]
+	 * @synopsis <directory> [<output-file>]
 	 */
 	public function generate( $args ) {
 		list( $directory, $output_file ) = $args;


### PR DESCRIPTION
It was giving this error when running `wp funcref generate`:

> Warning: The `wp funcref generate` command has an invalid synopsis
> part: `[<output_file>]`

It doesn’t like underscores, apparently.
