### PR TITLE
Fix an undefined offset notice when using the generate command

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -17,10 +17,12 @@ class Command extends WP_CLI_Command {
 	 * @synopsis <directory> [<output_file>]
 	 */
 	public function generate( $args ) {
-		list( $directory, $output_file ) = $args;
+		$directory = $args[0];
 
-		if ( empty( $output_file ) )
-			$output_file = 'phpdoc.json';
+		$output_file = 'phpdoc.json';
+		if ( ! empty( $args[1] ) ) {
+			$output_file = $args[1];
+		}
 
 		$directory = realpath( $directory );
 		$this->_load_libs();


### PR DESCRIPTION
When running `wp funcref generate <directory>`, an undefined offset
notice is being generated, because the optional `<output-file>`
argument is being treated as if it is required.

> PHP Notice:  Undefined offset: 1 in ../git/WP-Parser/cli.php on line 20
