### PR TITLE
Import hooks in class methods

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -223,7 +223,13 @@ class Importer {
 		foreach ( $data['methods'] as $method ) {
 			// Namespace method names with the class name
 			$method['name'] = $data['name'] . '-' . $method['name'];
-			$this->import_item( $method, $class_id, $import_internal );
+			$method_id = $this->import_item( $method, $class_id, $import_internal );
+
+			if ( ! empty( $data['hooks'] ) ) {
+				foreach ( $data['hooks'] as $hook ) {
+					$this->import_hook( $hook, $method_id, $import_internal );
+				}
+			}
 		}
 
 		return $class_id;


### PR DESCRIPTION
Note that the import messages for the in-method hooks wont be indented three levels as expected, but only two. I think that to fix this the indenting of the importer feedback messages needs to be refactored. I'll do that in another PR.

Fixes #57
