### PR TITLE
Better solution to ignore files in /wp-content. Fixes #80

### DIFF
--- a/lib/runner.php
+++ b/lib/runner.php
@@ -28,8 +28,25 @@ function parse_files( $files, $root ) {
 
 	foreach ( $files as $filename ) {
 
-		// Ignore anything in wp-content as it's not core.
-		if( ! stristr($filename, 'wp-content') ){
+		// Let's assume this file isn't in wp-content.
+		$is_wp_config_file = false;
+
+		// Cut out all the directories into an array.
+		$file_path = explode('/', $filename);
+
+		if( is_array($file_path) ){
+			foreach($file_path as $path){
+
+				// If one of the path's is wp-content, flag this file as a file
+				// in /wp-content which we don't want to process.
+				if('wp-content' == $path){
+					$is_wp_config_file = true;
+				}
+			}
+		}
+
+		// Only process file that aren't in /wp-content
+		if( ! $is_wp_config_file ){
 
 			$file = new File_Reflector( $filename );
 


### PR DESCRIPTION
I am assuming that the Parser doesn't need to parse `/wp-content` so this solution ignores files with `wp-content` in it's path which also fixes #80. Used this instead of `stristr` to make sure we're not ignoring some file that could possibly be called `wp-content-something.php` on day in core.
