### PR TITLE
Avoid duplicate entries for multi-use hooks

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -339,7 +339,14 @@ class Importer {
 		);
 
 		// Look for an existing post for this item
-		$existing_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_name = %s AND post_type = %s AND post_parent = %d LIMIT 1", $slug, $post_data['post_type'], (int) $parent_post_id ) );
+		$existing_post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = %s AND post_parent = %d LIMIT 1",
+				$data['name'],
+				$post_data['post_type'],
+				(int) $parent_post_id
+			)
+		);
 
 		// Insert/update the item post
 		if ( ! empty( $existing_post_id ) ) {


### PR DESCRIPTION
Check against the post title instead of the post slug. (Thanks
@GaryJones)

Fixes #42
