### PR TITLE
Fix warning for @since's that have no version number

### DIFF
--- a/lib/runner.php
+++ b/lib/runner.php
@@ -139,7 +139,10 @@ function export_docblock( $element ) {
 			$t['refers'] = $tag->getReference();
 		}
 		if ( 'since' == $tag->getName() && method_exists( $tag, 'getVersion' ) ) {
-			$t['content'] = $tag->getVersion();
+			$version = $tag->getVersion();
+			if ( !empty( $version ) ) {
+				$t['content'] = $version;
+			}
 		}
 		$output['tags'][] = $t;
 	}


### PR DESCRIPTION
Some functions in WP have lines like @since MU , and the phpDoc version parser won't return a valid number for these. This results in a "Warning: Cannot set @since term: A name is required for this term" message when parsing these functions.
