### PR TITLE
Make post type and taxonomy registration arguments filterable. Add labels.

### DIFF
--- a/lib/class-plugin.php
+++ b/lib/class-plugin.php
@@ -22,7 +22,7 @@ class Plugin {
 	 */
 	public function register_post_types() {
 
-		$supports = array( 'custom-fields', 'editor', 'excerpt', 'revisions', 'title', );
+		$supports = array( 'custom-fields', 'editor', 'excerpt', 'revisions', 'title' );
 
 		// Function post type.
 		$function_args = array(


### PR DESCRIPTION
Introduce two filters (with docs) which would allow outside forces (such as themes) to modify the post type and taxonomy registration args. This PR is submitted in conjunction with stripping the post type and taxonomy registrations from the wporg-developer theme.

See: Rarst/wporg-developer#11
