### PR TITLE
Add scribu/posts-to-posts to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,24 @@
 		"issues": "https://github.com/rmccue/WP-Parser/issues",
 		"source": "https://github.com/rmccue/WP-Parser"
 	},
+	"minimum-stability": "dev",
 	"require"    : {
 		"php"                     : ">=5.3.6",
 		"composer/installers"     : "~1.0",
 		"phpdocumentor/reflection": "~1.0",
-		"erusev/parsedown"        : "~0.9"
+		"erusev/parsedown"        : "~0.9",
+		"scribu/posts-to-posts"   : "dev-master"
 	},
 	"autoload"   : {
 		"classmap": ["lib"],
 		"files"   : ["lib/runner.php", "lib/template.php"]
+	},
+	"repositories": [
+		{ "type": "vcs", "url":  "https://github.com/scribu/wp-posts-to-posts.git" }
+	],
+	"extra": {
+		"installer-paths": {
+			"vendor/scribu/posts-to-posts": ["scribu/posts-to-posts"]
+		}
 	}
 }


### PR DESCRIPTION
minimum-stability set to "dev" because posts-to-posts requires scribu/scb-framework as dev-master. Dependency fails to load if parent project is not set to allow development branches.

Repository for posts-to-posts added manually because composer doesn't find it on its own.

Path for posts-to-posts manually set because type "wordpress-plugin" causes it to be installed in a wp-content directory created within this plugin directory.

Fixes #112
