### PR TITLE
Allow filtering of the post data just prior to an item import.

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -418,6 +418,14 @@ class Importer {
 			)
 		);
 
+		/**
+		 * Filter an import item's post data before it is updated or inserted.
+		 *
+		 * @param array       $post_data        Array of post data.
+		 * @param string|null $existing_post_id ID if the post already exists, null otherwise.
+		 */
+		$post_data = apply_filters( 'wp_parser_import_item_post_data', $post_data, $existing_post_id );
+
 		// Insert/update the item post
 		if ( ! empty( $existing_post_id ) ) {
 			$is_new_post     = false;


### PR DESCRIPTION
On DevHub, we're exploring the possibility of storing the parsed summary (long description) in meta instead of post_content. This filter would allow us to do that without overwriting what's in an existing item's post_content field -- which we plan to leverage for other purposes.

Cross-reference: https://meta.trac.wordpress.org/ticket/481
