### PR TITLE
Make plugin headers translatable

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Author URI: https://github.com/rmccue/WP-Parser/graphs/contributors
  * Plugin URI: https://github.com/rmccue/WP-Parser
  * Version:
- * Text Domain wp-parser
+ * Text Domain: wp-parser
  */
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {


### PR DESCRIPTION
WordPress makes plugin headers translatable, if the `Text Domain` header is present.
