### PR TITLE
Prevent an error when parsing test files

### DIFF
--- a/lib/class-hook-reflector.php
+++ b/lib/class-hook-reflector.php
@@ -21,8 +21,17 @@ class Hook_Reflector extends BaseReflector {
 		}
 
 		// two concatenated things, last one of them a variable
-		if ( preg_match( '/(?:[\'"]([^\'"]*)[\'"]\s*\.\s*)?(\$[^\s]*)(?:\s*\.\s*[\'"]([^\'"]*)[\'"])?/', $name, $m ) ) {
-			return $m[1].'{'.$m[2].'}'.$m[3];
+		if ( preg_match(
+			'/(?:[\'"]([^\'"]*)[\'"]\s*\.\s*)?' . // First filter name string (optional)
+			'(\$[^\s]*)' .                        // Dynamic variable
+			'(?:\s*\.\s*[\'"]([^\'"]*)[\'"])?/',  // Second filter name string (optional)
+			$name, $m ) ) {
+
+			if ( isset( $m[3] ) ) {
+				return $m[1] . '{' . $m[2] . '}' . $m[3];
+			} else {
+				return $m[1] . '{' . $m[2] . '}';
+			}
 		}
 
 		return $name;


### PR DESCRIPTION
When parsing test files there was an error that $m[3] didn't exist, check for that. $m[1] will always exist even though it is optional because of PHP's handling of preg_match.

Also improves clarity for the next reader.
