### PR TITLE
Update example filter to test multiple since tags

### DIFF
--- a/tests/source/filters.php
+++ b/tests/source/filters.php
@@ -115,7 +115,6 @@ $value = apply_filters("missing_param_double_quotes_dynamic_filter_$option", $va
  *
  * @since 1.0
  * @since 1.9 Added a new parameter to the filter
- * More description
  *
  * @param string $first_parameter
  * @param string $second_parameter


### PR DESCRIPTION
The description threw me when testing multiple since tags as I wasn't sure which way to interpret `* More description` on line 118 above.

Using the current theme (a519b5d) and importing the sample data you can see `More description` is added to the end of second `@since` description:
![wp-parser-multiple-since-description](https://cloud.githubusercontent.com/assets/1016458/4803169/cd6adc9a-5e52-11e4-9a4e-be41c258df2b.png)

I presume this is not meant to be the case? 

Most likely line 118 `* More description` should be also removed though I left it in for now as even testing this further as updating the source per below still appends `More description` to the `@since 1.9` description:

```
 * @since 1.0
 * @since 1.9 Added a new parameter to the filter
 *
 * More description
 *
 * @param string $first_parameter
```
