### PR TITLE
Removed check for functions, classes, hooks when importing the WP versio...

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -467,11 +467,6 @@ class Importer implements LoggerAwareInterface {
 			return;
 		}
 
-		// version.php should not contain functions, classes or hooks.
-		if ( isset( $data['functions'] ) || isset ( $data['classes'] ) ||  isset( $data['hooks'] ) ) {
-			return;
-		}
-
 		include $version_path;
 
 		if ( isset( $wp_version ) && $wp_version ) {


### PR DESCRIPTION
The WordPress version isn't imported with this check in place.
