### PR TITLE
Introduce a simple filter to re-enable skipping duplicate hooks when parsing

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -358,20 +358,31 @@ class Importer implements LoggerAwareInterface {
 	 * @return bool|int Post ID of this hook, false if any failure.
 	 */
 	public function import_hook( array $data, $parent_post_id = 0, $import_ignored = false ) {
+		/**
+		 * Filter whether to skip parsing duplicate hooks.
+		 *
+		 * "Duplicate hooks" are characterized in WordPress core by a preceding DocBlock comment
+		 * including the phrases "This action is documented in" or "This filter is documented in".
+		 *
+		 * Passing a truthy value will skip the parsing of duplicate hooks.
+		 *
+		 * @param bool $skip Whether to skip parsing duplicate hooks. Default false.
+		 */
+		$skip_duplicates = apply_filters( 'wp_parser_skip_duplicate_hooks', false );
 
-		/* TODO core-centric assumption, shouldn't be handled on import step
-		if ( 0 === strpos( $data['doc']['description'], 'This action is documented in' ) ) {
-			return false;
-		}
+		if ( false !== $skip_duplicates ) {
+			if ( 0 === strpos( $data['doc']['description'], 'This action is documented in' ) ) {
+				return false;
+			}
 
-		if ( 0 === strpos( $data['doc']['description'], 'This filter is documented in' ) ) {
-			return false;
-		}
+			if ( 0 === strpos( $data['doc']['description'], 'This filter is documented in' ) ) {
+				return false;
+			}
 
-		if ( '' === $data['doc']['description'] && '' === $data['doc']['long_description'] ) {
-			return false;
+			if ( '' === $data['doc']['description'] && '' === $data['doc']['long_description'] ) {
+				return false;
+			}
 		}
-		*/
 
 		$hook_id = $this->import_item( $data, $parent_post_id, $import_ignored, array( 'post_type' => $this->post_type_hook ) );
 


### PR DESCRIPTION
The skipping of parsing duplicate hooks is necessary to facilitate parsing of WordPress core. This hook simply adds a way to re-enable skipping of duplicate hooks for that use-case. See 45ff10ed656ad783b9e68f368d3b208040715170 for where it was disabled.

Re-enabling is as simple as:
`add_filter( 'wp_parser_skip_duplicate_hooks', '__return_true' );`