### PR TITLE
Travis CI: update php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
+  - 5.6
   - 5.5
   - 5.4
-  - 5.3
   - hhvm
 
 install: composer install --no-dev


### PR DESCRIPTION
We no longer support 5.3, so there is no need to test against it. (However, note that the parser tests currently still run fine and pass on PHP 5.3.)

PHP 5.6 is now stable, so we should be testing against it.