### PR TITLE
Add programming language support.

### DIFF
--- a/lib/class-command.php
+++ b/lib/class-command.php
@@ -63,8 +63,13 @@ class Command extends WP_CLI_Command {
 			exit;
 		}
 
+		$language = 'PHP';
+		if ( isset( $assoc_args['language'] ) ) {
+			$language = $assoc_args['language'];
+		}
+
 		// Import data
-		$this->_do_import( $phpdoc, isset( $assoc_args['quick'] ), isset( $assoc_args['import-internal'] ) );
+		$this->_do_import( $phpdoc, isset( $assoc_args['quick'] ), isset( $assoc_args['import-internal'] ), $language );
 	}
 
 	/**
@@ -122,11 +127,12 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Import the PHPDoc $data into WordPress posts and taxonomies
 	 *
-	 * @param array $data
-	 * @param bool  $skip_sleep     If true, the sleep() calls are skipped.
-	 * @param bool  $import_ignored If true, functions marked `@ignore` will be imported.
+	 * @param array  $data
+	 * @param bool   $skip_sleep     Optional; defaults to false. If true, the sleep() calls are skipped.
+	 * @param bool   $import_ignored Optional; defaults to false. If true, functions marked `@ignore` will be imported.
+	 * @param string $language       Optional; defaults to 'PHP'. The programming language of the documentation being imported.
 	 */
-	protected function _do_import( array $data, $skip_sleep = false, $import_ignored = false ) {
+	protected function _do_import( array $data, $skip_sleep = false, $import_ignored = false, $language = 'PHP' ) {
 
 		if ( ! wp_get_current_user()->exists() ) {
 			WP_CLI::error( 'Please specify a valid user: --user=<id|login>' );
@@ -136,7 +142,7 @@ class Command extends WP_CLI_Command {
 		// Run the importer
 		$importer = new Importer;
 		$importer->setLogger( new WP_CLI_Logger() );
-		$importer->import( $data, $skip_sleep, $import_ignored );
+		$importer->import( $data, $skip_sleep, $import_ignored, $language );
 
 		WP_CLI::line();
 	}


### PR DESCRIPTION
For the parent trac issue please see: https://meta.trac.wordpress.org/ticket/3063.

In order to add the Gutenberg JSDoc into the code reference we'd want to be able to differentiate between JS and PHP functions, classes etc.

I've written a simple JSDoc template at https://github.com/herregroen/jsdoc-parser that converts JSDoc into a JSON format compatible with this plugin's import.

But importing that could potentially lead to conflicts as PHP and JS functions/classes might have the same names. This PR expands the structure of the plugin to support multiple programming languages. For now it's just a simple direct approach that needs further testing but I wanted to share it as soon as possible in order to gather input.

I've chosen to explicitly add `php` as well which means that all existing posts would have their name changed as well. Which means migrating would be a concern. 
- Should the plugin automatically move any existing functions / classes / hooks to the PHP language?
- As the URL of these things will change to include the programming language should the plugin take care of redirects to those?
- Should other taxonomies be language specific? Is the JS since the same as the PHP since? Especially namespaces are a likely candidate for something that should be language specific.