### PR TITLE
Add filters to exclude directories and files before import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
     - php: hhvm
 
 before_install:
-    - export PATH="$HOME/.composer/vendor/bin:$PATH"
-    - composer global require "phpunit/phpunit=4.8.*"
     # Setup WP_TESTS_DIR (needed to bootstrap WP PHPUnit tests). 
     - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit/
     # Clone the WordPress develop repo.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
     # Setup WP_TESTS_DIR (needed to bootstrap WP PHPUnit tests). 
     - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit/
     # Clone the WordPress develop repo.
-    - git clone --depth=1 --branch="4.9" git://develop.git.wordpress.org/ /tmp/wordpress/
+    - git clone --depth=1 --branch="4.3" git://develop.git.wordpress.org/ /tmp/wordpress/
     # Setup DB.
     - mysql -e "CREATE DATABASE wordpress_test;" -uroot
     # Setup wp-config.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
     # Setup WP_TESTS_DIR (needed to bootstrap WP PHPUnit tests). 
     - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit/
     # Clone the WordPress develop repo.
-    - git clone --depth=1 --branch="4.3" git://develop.git.wordpress.org/ /tmp/wordpress/
+    - git clone --depth=1 --branch="4.9" git://develop.git.wordpress.org/ /tmp/wordpress/
     # Setup DB.
     - mysql -e "CREATE DATABASE wordpress_test;" -uroot
     # Setup wp-config.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     - php: hhvm
 
 before_install:
+    - export PATH="$HOME/.composer/vendor/bin:$PATH"
+    - composer global require "phpunit/phpunit=4.8.*"
     # Setup WP_TESTS_DIR (needed to bootstrap WP PHPUnit tests). 
     - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit/
     # Clone the WordPress develop repo.


### PR DESCRIPTION
As discussed in #198 there should be a filter to skip directories before importing files.

This PR adds three filters to exclude directories and files before import.

**Note**: I've closed PR #201 to move these changes to it's own branch and reverted the changes made to the travis.yml file. Those changes should be done in a separate PR.