### PR TITLE
Add introduced, modified and deprecated version post meta to imported posts

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -646,10 +646,10 @@ class Importer implements LoggerAwareInterface {
 			// Loop through all @since versions.
 			foreach ( $since_versions as $since_version ) {
 
-				if ( ! empty( $since_version['content'] ) ) {
+				if ( ! empty( $since_version['content'] ) && maybe_version( $since_version['content'] ) ) {
 					$since_term = $this->insert_term( $since_version['content'], $this->taxonomy_since_version );
 
-					// Assign the tax item to the post
+					// Assign the tax item to the post.
 					if ( ! is_wp_error( $since_term ) ) {
 						$added_term_relationship = did_action( 'added_term_relationship' );
 						wp_set_object_terms( $post_id, (int) $since_term['term_id'], $this->taxonomy_since_version, true );
@@ -662,6 +662,28 @@ class Importer implements LoggerAwareInterface {
 				}
 			}
 		}
+
+		$deprecated_version = wp_list_filter( $data['doc']['tags'], array( 'name' => 'deprecated' ) );
+		$deprecated_version = array_shift( $deprecated_version );
+
+		$is_deprecated = isset( $deprecated_version['content'] ) && ! empty( $deprecated_version['content'] );
+		if ( $is_deprecated && maybe_version( $deprecated_version['content'] ) ) {
+			$deprecated_term = $this->insert_term( $deprecated_version['content'], $this->taxonomy_since_version );
+
+			// Assign the deprecated tax item to the post.
+			if ( ! is_wp_error( $since_term ) ) {
+				$added_term_relationship = did_action( 'added_term_relationship' );
+				wp_set_object_terms( $post_id, (int) $deprecated_term['term_id'], $this->taxonomy_since_version, true );
+				if ( did_action( 'added_term_relationship' ) > $added_term_relationship ) {
+					$anything_updated[] = true;
+				}
+			} else {
+				$this->logger->warning( "\tCannot set deprecated @since term: " . $since_term->get_error_message() );
+			}
+		}
+
+		// Assign 'introduced', 'modified' and 'deprecated' meta to the post.
+		$anything_updated[] = $this->_set_since_meta( $post_id, $since_versions, $deprecated_version );
 
 		$packages = array(
 			'main' => wp_list_filter( $data['doc']['tags'], array( 'name' => 'package' ) ),
@@ -821,5 +843,59 @@ class Importer implements LoggerAwareInterface {
 				$this->anything_updated[] = true;
 			}
 		}
+	}
+
+	/**
+	 * Set version meta.
+	 *
+	 * Imports introduced, modified, and deprecated post meta.
+	 *
+	 * @param int   $post_id            Post ID.
+	 * @param array $since_versions     Array with DocBlock data from versions.
+	 * @param array $deprecated_version DocBlock deprecated version data.
+	 * @return bool True if any meta whas updated
+	 */
+	protected function _set_since_meta( $post_id, $since_versions, $deprecated_version ) {
+		$anything_updated   = array();
+		$introduced_version = array_shift( $since_versions );
+		$introduced = isset( $introduced_version['content'] ) && $introduced_version['content'];
+
+		if ( $introduced && maybe_version( $introduced_version['content'] ) ) {
+			$anything_updated[] = update_post_meta( $post_id, 'wp_parser_introduced', $introduced_version['content'] );
+		} else {
+			delete_post_meta( $post_id, 'wp_parser_introduced' );
+		}
+
+		$deprecated = isset( $deprecated_version['content'] ) && $deprecated_version['content'];
+		if ( $deprecated && maybe_version( $deprecated_version['content']  ) ) {
+			$anything_updated[] = update_post_meta( $post_id, 'wp_parser_deprecated', $deprecated_version['content'] );
+		} else {
+			delete_post_meta( $post_id, 'wp_parser_deprecated' );
+		}
+
+		$old_meta = get_post_meta( $post_id, 'wp_parser_modified' );
+		$new_meta = array();
+
+		// Delete modified meta and check if anything was updated after adding new meta.
+		delete_post_meta( $post_id, 'wp_parser_modified' );
+
+		if ( ! empty( $since_versions ) ) {
+			foreach ( $since_versions as $since ) {
+				$modified = $since['content'] && $since['content'];
+				if ( ! ( $modified && maybe_version( $since['content'] ) ) ) {
+					continue;
+				}
+
+				$new_meta[] = $since['content'];
+				add_post_meta( $post_id, 'wp_parser_modified', $since['content'] );
+			}
+		}
+
+		$diff_meta          = array_diff( $old_meta, $new_meta );
+		$anything_updated[] = ! empty( $diff_meta );
+		$anything_updated[] = empty( $old_meta ) && ! empty( $new_meta );
+		$anything_updated   = array_filter( $anything_updated );
+
+		return ! empty( $anything_updated );
 	}
 }

--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -858,26 +858,26 @@ class Importer implements LoggerAwareInterface {
 	protected function _set_since_meta( $post_id, $since_versions, $deprecated_version ) {
 		$anything_updated   = array();
 		$introduced_version = array_shift( $since_versions );
-		$introduced = isset( $introduced_version['content'] ) && $introduced_version['content'];
 
+		$introduced = isset( $introduced_version['content'] ) && $introduced_version['content'];
 		if ( $introduced && maybe_version( $introduced_version['content'] ) ) {
-			$anything_updated[] = update_post_meta( $post_id, 'wp_parser_introduced', $introduced_version['content'] );
+			$anything_updated[] = update_post_meta( $post_id, '_wp-parser_introduced', $introduced_version['content'] );
 		} else {
-			delete_post_meta( $post_id, 'wp_parser_introduced' );
+			delete_post_meta( $post_id, '_wp-parser_introduced' );
 		}
 
 		$deprecated = isset( $deprecated_version['content'] ) && $deprecated_version['content'];
 		if ( $deprecated && maybe_version( $deprecated_version['content']  ) ) {
-			$anything_updated[] = update_post_meta( $post_id, 'wp_parser_deprecated', $deprecated_version['content'] );
+			$anything_updated[] = update_post_meta( $post_id, '_wp-parser_deprecated', $deprecated_version['content'] );
 		} else {
-			delete_post_meta( $post_id, 'wp_parser_deprecated' );
+			delete_post_meta( $post_id, '_wp-parser_deprecated' );
 		}
 
-		$old_meta = get_post_meta( $post_id, 'wp_parser_modified' );
+		$old_meta = get_post_meta( $post_id, '_wp-parser_modified' );
 		$new_meta = array();
 
 		// Delete modified meta and check if anything was updated after adding new meta.
-		delete_post_meta( $post_id, 'wp_parser_modified' );
+		delete_post_meta( $post_id, '_wp-parser_modified' );
 
 		if ( ! empty( $since_versions ) ) {
 			foreach ( $since_versions as $since ) {
@@ -887,7 +887,7 @@ class Importer implements LoggerAwareInterface {
 				}
 
 				$new_meta[] = $since['content'];
-				add_post_meta( $post_id, 'wp_parser_modified', $since['content'] );
+				add_post_meta( $post_id, '_wp-parser_modified', $since['content'] );
 			}
 		}
 

--- a/lib/template.php
+++ b/lib/template.php
@@ -348,12 +348,12 @@ function maybe_version( $version ) {
 	/**
 	 * Whether a version should be checked or not.
 	 *
-	 * This filter allows you to do your own version validation by returning a boolean.
+	 * Return boolean to validate the version yourself.
 	 *
 	 * @param mixed  $check_version. Whether to check the version or not. Default null.
 	 * @param string $version        Version string.
 	 */
-	$check_version = apply_filters( 'wp_parser_maybe_version', null, $version );
+	$check_version = apply_filters( 'wp_parser_check_version', null, $version );
 	if ( is_bool( $check_version ) ) {
 		return $check_version;
 	}

--- a/lib/template.php
+++ b/lib/template.php
@@ -328,3 +328,39 @@ function get_source_link() {
 
 	return $trac_url;
 }
+
+/**
+ * Check whether a string resembles a version.
+ *
+ * A version should start with a numeric value.
+ * The only non numeric versions that are allowed start with "mu" and "unknown".
+ *
+ * Note: the version validation is very minimal and doesn't check semantic versioning or
+ * any other type of version specifications.
+ *
+ * @param  string $version The version to check.
+ * @return bool True if it resembles a version.
+ */
+function maybe_version( $version ) {
+
+	$version = strtolower( trim( (string) $version ) );
+
+	/**
+	 * Whether a version should be checked or not.
+	 *
+	 * This filter allows you to do your own version validation by returning a boolean.
+	 *
+	 * @param mixed  $check_version. Whether to check the version or not. Default null.
+	 * @param string $version        Version string.
+	 */
+	$check_version = apply_filters( 'wp_parser_maybe_version', null, $version );
+	if ( is_bool( $check_version ) ) {
+		return $check_version;
+	}
+
+	$mu      = ( 0 === strpos( $version, 'mu' ) );
+	$unknown = ( 0 === strpos( $version, 'unknown' ) );
+	$numeric = preg_match( '/^\d/', $version );
+
+	return $mu || $unknown || $numeric;
+}


### PR DESCRIPTION
As disscussed in [ticked #2847](https://meta.trac.wordpress.org/ticket/2847) there is no easy way to query for posts with these type of change versions. This pull request imports the different change versions as post meta.

For example, with this pull request you can now query for deprecated functions in WordPress 4.9 like this.

```php
$args = array(
	'post_type'  => 'wp-parser-function',
	'meta_key'   => '_wp-parser_deprecated',
	'meta_value' => '4.9.0',
);

$deprecated_query = new WP_Query($args);
```

This pull request also assigns a deprecated `@since` version term to imported (deprecated) posts.
See [ticket #3699](https://meta.trac.wordpress.org/ticket/3699)

This allows for deprecated posts to also be included in the since archives. Some deprecated versions (in the source code DocBlocks) are not correctly formatted. That's why a new function `maybe_version()` is used to do a very minimal check before assigning term and meta versions.

Without this pull request 95 `@since` terms are imported (WP 4.9.8)
The same number is imported with the `maybe_version()` check only added to the import of normal `@since` terms.
With this pull request 97 `@since` terms are imported.

This means 2 extra `@since` version terms (3.4.1 and mu) are imported for deprecated versions.

**Note** This pull request is a copy of the closed pull request #205 as I had to move the changes to its own branch 