### PR TITLE
Fix PHPUnit errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,50 @@ matrix:
     - php: 5.6
     - php: 5.5
     - php: 5.4
-    - php: hhvm
 
 before_install:
-    # Setup WP_TESTS_DIR (needed to bootstrap WP PHPUnit tests). 
-    - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit/
-    # Clone the WordPress develop repo.
-    - git clone --depth=1 --branch="4.3" git://develop.git.wordpress.org/ /tmp/wordpress/
-    # Setup DB.
-    - mysql -e "CREATE DATABASE wordpress_test;" -uroot
-    # Setup wp-config.
-    - cp /tmp/wordpress/wp-tests-config-sample.php /tmp/wordpress/wp-tests-config.php
-    - sed -i "s/youremptytestdbnamehere/wordpress_test/" /tmp/wordpress/wp-tests-config.php
-    - sed -i "s/yourusernamehere/root/" /tmp/wordpress/wp-tests-config.php
-    - sed -i "s/yourpasswordhere//" /tmp/wordpress/wp-tests-config.php
+  # Setup WP_TESTS_DIR (needed to bootstrap WP PHPUnit tests).
+  - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit/
+  # http serves a single offer, whereas https serves multiple. we only want one
+  - curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
+  - WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+  - printf "Cloning WordPress %s\n" "$WP_VERSION"
+  # Clone the WordPress develop repo.
+  - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress/
+  # Setup DB.
+  - mysql -e "CREATE DATABASE wordpress_test;" -uroot
+  # Setup wp-config.
+  - cp /tmp/wordpress/wp-tests-config-sample.php /tmp/wordpress/wp-tests-config.php
+  - sed -i "s/youremptytestdbnamehere/wordpress_test/" /tmp/wordpress/wp-tests-config.php
+  - sed -i "s/yourusernamehere/root/" /tmp/wordpress/wp-tests-config.php
+  - sed -i "s/yourpasswordhere//" /tmp/wordpress/wp-tests-config.php
 
 install: composer install --no-dev
+
+before_script:
+  - |
+    # Export Composer's global bin dir to PATH, but not on PHP 5.2:
+    if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
+      composer config --list --global
+      export PATH=`composer config --list --global | grep '\[home\]' | { read a; echo "${a#* }/vendor/bin:$PATH"; }`
+    fi
+  - |
+    # Install the specified version of PHPUnit depending on the PHP version:
+    case "$TRAVIS_PHP_VERSION" in
+      7.3|7.2|7.1|7.0|nightly)
+        echo "Using PHPUnit 6.x"
+        travis_retry composer global require "phpunit/phpunit:^6"
+        # See trac ticket #43218 for when we can use PHPUnit 7
+        ;;
+      5.6|5.5|5.4|5.3)
+        echo "Using PHPUnit 4.x"
+        travis_retry composer global require "phpunit/phpunit:^4"
+        ;;
+      *)
+        echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"
+        exit 1
+        ;;
+    esac
 
 script:
   - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 matrix:
   include:
+    - php: 7.2
     - php: 7.1
     - php: 7.0
     - php: 5.6

--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -171,7 +171,10 @@ class File_Reflector extends FileReflector {
 				break;
 
 			case 'Stmt_Function':
-				end( $this->functions )->uses = array_pop( $this->location )->uses;
+				$function = array_pop( $this->location );
+				if ( isset( $function->uses ) && ! empty( $function->uses ) ) {
+					end( $this->functions )->uses = $function->uses;
+				}
 				break;
 
 			case 'Stmt_ClassMethod':


### PR DESCRIPTION
The (travis-ci) unit tests are failing because not all PHPUnit versions are compatible with the `WP_UnitTestCase` class from WordPress. 

This pull requests replaces  the [ hard coded WP version](https://github.com/WordPress/phpdoc-parser/blob/e482b28d6cb3761f0a2d69a2ea97fd19a0b22e7a/.travis.yml#L18) (4.3) with the latest WP version by calling the WordPress API. It then installs the correct PHPUnit version depending on the PHP version. PHPUnit 7 is not yet supported. See ticket [#43218](https://core.trac.wordpress.org/ticket/43218).

The errors discussed in issue #206 are because the [nikic/php-parser](https://github.com/nikic/PHP-Parser) v1.2.0+ doesn't use magic getters anymore. This is fixed by checking if the property exist before referencing it.

This PR also removes testing for `hhvm` as that's no longer needed in my opinion.