### PR TITLE
Add namespaced classes for the  PHP Parser

### DIFF
--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -40,7 +40,7 @@ class File_Reflector extends FileReflector {
 	/**
 	 * Last DocBlock associated with a non-documentable element.
 	 *
-	 * @var \PHPParser_Comment_Doc
+	 * @var \PhpParser\Comment\Doc
 	 */
 	protected $last_doc = null;
 

--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -61,9 +61,9 @@ class File_Reflector extends FileReflector {
 	 * Finally, we pick up any docblocks for nodes that usually aren't documentable,
 	 * so they can be assigned to the hooks to which they may belong.
 	 *
-	 * @param \PHPParser_Node $node
+	 * @param \PhpParser\Node $node
 	 */
-	public function enterNode( \PHPParser_Node $node ) {
+	public function enterNode( \PhpParser\Node $node ) {
 		parent::enterNode( $node );
 
 		switch ( $node->getType() ) {
@@ -137,9 +137,9 @@ class File_Reflector extends FileReflector {
 	 * We can now access the function/method reflectors, so we can assign any queued
 	 * hooks to them. The reflector for a node isn't created until the node is left.
 	 *
-	 * @param \PHPParser_Node $node
+	 * @param \PhpParser\Node $node
 	 */
-	public function leaveNode( \PHPParser_Node $node ) {
+	public function leaveNode( \PhpParser\Node $node ) {
 
 		parent::leaveNode( $node );
 
@@ -189,11 +189,11 @@ class File_Reflector extends FileReflector {
 	}
 
 	/**
-	 * @param \PHPParser_Node $node
+	 * @param \PhpParser\Node $node
 	 *
 	 * @return bool
 	 */
-	protected function isFilter( \PHPParser_Node $node ) {
+	protected function isFilter( \PhpParser\Node $node ) {
 		// Ignore variable functions
 		if ( 'Name' !== $node->name->getType() ) {
 			return false;
@@ -221,13 +221,13 @@ class File_Reflector extends FileReflector {
 	}
 
 	/**
-	 * @param \PHPParser_Node $node
+	 * @param \PhpParser\Node $node
 	 *
 	 * @return bool
 	 */
-	protected function isNodeDocumentable( \PHPParser_Node $node ) {
+	protected function isNodeDocumentable( \PhpParser\Node $node ) {
 		return parent::isNodeDocumentable( $node )
-		|| ( $node instanceof \PHPParser_Node_Expr_FuncCall
+		|| ( $node instanceof \PhpParser\Node\Expr\FuncCall
 			&& $this->isFilter( $node ) );
 	}
 }

--- a/lib/class-function-call-reflector.php
+++ b/lib/class-function-call-reflector.php
@@ -25,24 +25,24 @@ class Function_Call_Reflector extends BaseReflector {
 
 		$shortName = $this->getShortName();
 
-		if ( is_a( $shortName, 'PHPParser_Node_Name_FullyQualified' ) ) {
+		if ( is_a( $shortName, 'PhpParser\Node\Name\FullyQualified' ) ) {
 			return '\\' . (string) $shortName;
 		}
 
-		if ( is_a( $shortName, 'PHPParser_Node_Name' ) ) {
+		if ( is_a( $shortName, 'PhpParser\Node\Name' ) ) {
 			return (string) $shortName;
 		}
 
-		/** @var \PHPParser_Node_Expr_ArrayDimFetch $shortName */
-		if ( is_a( $shortName, 'PHPParser_Node_Expr_ArrayDimFetch' ) ) {
+		/** @var \PhpParser\Node\Expr\ArrayDimFetch $shortName */
+		if ( is_a( $shortName, 'PhpParser\Node\Expr\ArrayDimFetch' ) ) {
 			$var = $shortName->var->name;
 			$dim = $shortName->dim->name->parts[0];
 
 			return "\${$var}[{$dim}]";
 		}
 
-		/** @var \PHPParser_Node_Expr_Variable $shortName */
-		if ( is_a( $shortName, 'PHPParser_Node_Expr_Variable' ) ) {
+		/** @var \PhpParser\Node\Expr\Variable $shortName */
+		if ( is_a( $shortName, 'PhpParser\Node\Expr\Variable' ) ) {
 			return $shortName->name;
 		}
 

--- a/lib/class-hook-reflector.php
+++ b/lib/class-hook-reflector.php
@@ -3,7 +3,7 @@
 namespace WP_Parser;
 
 use phpDocumentor\Reflection\BaseReflector;
-use PHPParser_PrettyPrinter_Default;
+use \PhpParser\PrettyPrinter\Standard;
 
 /**
  * Custom reflector for WordPress hooks.
@@ -14,7 +14,7 @@ class Hook_Reflector extends BaseReflector {
 	 * @return string
 	 */
 	public function getName() {
-		$printer = new PHPParser_PrettyPrinter_Default;
+		$printer = new \PhpParser\PrettyPrinter\Standard;
 		return $this->cleanupName( $printer->prettyPrintExpr( $this->node->args[0]->value ) );
 	}
 

--- a/lib/class-method-call-reflector.php
+++ b/lib/class-method-call-reflector.php
@@ -32,22 +32,22 @@ class Method_Call_Reflector extends BaseReflector {
 			$caller = $this->node->var;
 		}
 
-		if ( $caller instanceof \PHPParser_Node_Expr ) {
+		if ( $caller instanceof \PhpParser\Node\Expr ) {
 			$printer = new Pretty_Printer;
 			$caller = $printer->prettyPrintExpr( $caller );
-		} elseif ( $caller instanceof \PHPParser_Node_Name_FullyQualified ) {
+		} elseif ( $caller instanceof \PhpParser\Node\Name\FullyQualified ) {
 			$caller = '\\' . $caller->toString();
-		} elseif ( $caller instanceof \PHPParser_Node_Name ) {
+		} elseif ( $caller instanceof \PhpParser\Node\Name ) {
 			$caller = $caller->toString();
 		}
 
 		$caller = $this->_resolveName( $caller );
 
 		// If the caller is a function, convert it to the function name
-		if ( is_a( $caller, 'PHPParser_Node_Expr_FuncCall' ) ) {
+		if ( is_a( $caller, 'PhpParser\Node\Expr\FuncCall' ) ) {
 
 			// Add parentheses to signify this is a function call
-			/** @var \PHPParser_Node_Expr_FuncCall $caller */
+			/** @var \PhpParser\Node\Expr\FuncCall $caller */
 			$caller = implode( '\\', $caller->name->parts ) . '()';
 		}
 

--- a/lib/class-pretty-printer.php
+++ b/lib/class-pretty-printer.php
@@ -2,21 +2,21 @@
 
 namespace WP_Parser;
 
-use PHPParser_Node_Arg;
-use PHPParser_PrettyPrinter_Default;
+use PhpParser\Node\Arg;
+use PhpParser\PrettyPrinter\Standard;
 
 /**
  * Extends default printer for arguments.
  */
-class Pretty_Printer extends PHPParser_PrettyPrinter_Default {
+class Pretty_Printer extends \PhpParser\PrettyPrinter\Standard {
 	/**
 	 * Pretty prints an argument.
 	 *
-	 * @param PHPParser_Node_Arg $node Expression argument
+	 * @param PhpParser\Node\Arg $node Expression argument
 	 *
 	 * @return string Pretty printed argument
 	 */
-	public function prettyPrintArg( PHPParser_Node_Arg $node ) {
+	public function prettyPrintArg( \PhpParser\Node\Arg $node ) {
 		return str_replace( "\n" . $this->noIndentToken, "\n", $this->p( $node ) );
 	}
 }

--- a/lib/class-static-method-call-reflector.php
+++ b/lib/class-static-method-call-reflector.php
@@ -14,7 +14,7 @@ class Static_Method_Call_Reflector extends Method_Call_Reflector {
 	 */
 	public function getName() {
 		$class = $this->node->class;
-		$prefix = ( is_a( $class, 'PHPParser_Node_Name_FullyQualified' ) ) ? '\\' : '';
+		$prefix = ( is_a( $class, 'PhpParser\Node\Name\FullyQualified' ) ) ? '\\' : '';
 		$class = $prefix . $this->_resolveName( implode( '\\', $class->parts ) );
 
 		return array( $class, $this->getShortName() );


### PR DESCRIPTION
In e482b28d6cb3761f0a2d69a2ea97fd19a0b22e7a the [phpdocumentor/reflection](https://github.com/phpDocumentor/Reflection) requirement was updated to version 3. This change also updated the  [nikic/php-parser](https://github.com/nikic/PHP-Parser)  requirement (from  phpdocumentor/reflection) to version 1.

In that version of the PHP Parser  all classes changed by using namespaced names with the `PhpParser` vendor prefix.

The old non namespaced classes are still supported, but are not recommended. They are [pointed to the name spaced versions](https://github.com/nikic/PHP-Parser/blob/f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51/lib/PhpParser/Autoloader.php#L89
) with a class alias.

This PR updates all uses of  PHP Parser  classes to their namespaced versions.