### PR TITLE
Use regex to make the newer PHP syntax work in the older PHP Parser we're using.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ After that install the dependencies using composer in the parser directory:
 composer install
 ```
 
+TEMPORARILY until the plugin supports the newer PHP syntax used within Core.
+```bash
+composer compat:munge
+```
+
 ## Running
 Activate the plugin first:
 

--- a/compat-reflector-munge.php
+++ b/compat-reflector-munge.php
@@ -1,0 +1,20 @@
+<?php
+
+if ( ! file_exists( __DIR__ . '/vendor/phpdocumentor/reflection/src/phpDocumentor/Reflection/BaseReflector.php' ) ) {
+	echo "Run 'composer install' first.\n";
+	exit(1);
+}
+
+$contents = file_get_contents( __DIR__ . '/vendor/phpdocumentor/reflection/src/phpDocumentor/Reflection/BaseReflector.php' );
+
+$contents = preg_replace(
+	'/function getShortName().+?{/is',
+	'function getShortName() {
+		if ( method_exists( $this->node, "isAnonymous" ) && $this->node->isAnonymous() ) {
+		 	return "AnonymousClass";
+		}
+	',
+	$contents
+);
+
+file_put_contents( __DIR__ . '/vendor/phpdocumentor/reflection/src/phpDocumentor/Reflection/BaseReflector.php', $contents );

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
 	"scripts"    : {
 		"test": "phpunit",
 		"test:watch": "phpunit-watcher watch < /dev/tty",
-		"test:coverage": "php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-html coverage"
+		"test:coverage": "php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-html coverage",
+		"compat:munge": "php compat-reflector-munge.php"
 	},
 	"autoload"   : {
 		"classmap": ["lib"],

--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -44,6 +44,82 @@ class File_Reflector extends FileReflector {
 	 */
 	protected $last_doc = null;
 
+	public function __construct( $file, $validate = false, $encoding = 'utf-8' ) {
+		parent::__construct( $file, false /* Force validation off */, $encoding );
+
+		// Nullable types are unknown to the parser, pretend they don't exist.
+		// The nullable type should be listed in the PHPDoc anyway.
+		$this->contents = preg_replace_callback(
+			'/(function [a-z0-9-_]+\([^{:]*?)\)(\:\s*\??\S+)?\s*[{;]/im',
+			static function( $m ) {
+				return preg_replace( '/\?(\S+)/', '$1', $m[0] ) ?: $m[0];
+			},
+			$this->contents
+		);
+
+		// Inline callables... ( $var )( $param ) can usualy be rewritten as $var( $param ).
+		$this->contents = preg_replace_callback(
+			'/(?:\s)(\(\s*\$[^()]+\))(\(.+\))/',
+			static function( $m ) {
+				return trim( $m[1], '() ' ) . trim( $m[2] );
+			},
+			$this->contents
+		);
+
+		// Short list() syntax...
+		$this->contents = preg_replace_callback(
+			'/(\s)\[(\s*\$[^();.*]{3,}?)\]\s*=/ism',
+			static function( $m ) {
+				return $m[1] . 'list( ' . $m[2] . ' ) =';
+			},
+			$this->contents
+		);
+
+		// Visibility on constants
+		$this->contents = preg_replace_callback(
+			'/\b(public|protected|private)\s+const\s+/im',
+			static function( $m ) {
+				return 'const ';
+			},
+			$this->contents
+		);
+
+		// constant arrays weren't supported.
+		$this->contents = preg_replace_callback(
+			'/\b(?<!\$|\[)([A-Z_]{5,})\[ ([^]]+)\]/',
+			function( $m ) {
+				return '$' . $m[1] . '[' . $m[2] . ']';
+			},
+			$this->contents
+		);
+
+		// Static calls on static calls. Mostly in tests.
+		$this->contents = preg_replace_callback(
+			'/([\$\[\]_a-z]+)::([\$\[\]_a-z]+)::([\$\[\]_a-z]+)/',
+			static function( $m ) {
+				//var_dump( $m );
+				if ( 'self' === $m[1] || 'static' === $m[1] ) {
+					return '$this->' . $m[2] . '->' . $m[3];
+				}
+
+				return $m[1] . '->' . $m[2]. '->' . $m[3];
+			},
+			$this->contents
+		);
+
+		// Static calls on function results. Mostly in tests.
+		$this->contents = preg_replace_callback(
+			'/([a-z_])\(\)::/',
+			static function( $m ) {
+				return $m[1] . '()->';
+			},
+			$this->contents
+		);
+
+		// Recalculate the hash, since we probably changed the contents.
+		$this->hash = md5($this->contents);
+	}
+
 	/**
 	 * Add hooks to the queue and update the node stack when we enter a node.
 	 *


### PR DESCRIPTION
See #246, #228.

Since I have no hope of personally being able to upgrade the parser any time soon, I took a different approach of making the existing parser work with current-day WordPress.

This requires "downgrading" PHP syntax used in Core to a syntax that the parser recognises.

I've attempted to not edit the source files on disk, such that the source importer gets the correct source.

I've attempted to keep the syntax that it's converted to mostly the same meaning as the existing code, this ensures that any fancyness in resolving that the parser includes still works.

There may have been libraries to transpile WordPress into PHP5 syntax, but I didn't want to use this as it would alter the line numbers of code, causing the source extractor to fail to find the correct code.

This has been tested within the included wp-env environment only.

Unfortunately I didn't take note of examples of the code that each regex is affecting, so you might just have to take my word for it..
I'll try running this on WordPress.org tomorrow to update developer.w.org