### PR TITLE
Update wp-env and deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/env": "^11.11.0",
+        "@wordpress/env": "^11.12.0",
         "npm-run-all": "^4.1.5"
       }
     },
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.11.0.tgz",
-      "integrity": "sha512-E4Riaan41uAcm70FFTD78Z1qtObQJwRlIyXdsr04X+mrg8XkBuHSqM1iSvgqnOpVzUuF9EYANYKF0CTm9tKW5w==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.12.0.tgz",
+      "integrity": "sha512-P1mYGEgnkYCbBPRaT9uAyxe3hFfsfkvxXKQ+Pfb00z/mXz5xbPC48ZdXTQmxTcpaj0nDwJfrBz0vzc074B5nrA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0",
@@ -1427,7 +1427,7 @@
         "js-yaml": "^3.15.0",
         "ora": "^4.0.2",
         "rimraf": "^5.0.10",
-        "simple-git": "^3.24.0",
+        "simple-git": "^3.32.3",
         "yargs": "^17.3.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1856,9 +1856,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/wordpress/phpdoc-parser#readme",
   "dependencies": {
-    "@wordpress/env": "^11.11.0",
+    "@wordpress/env": "^11.12.0",
     "npm-run-all": "^4.1.5"
   }
 }


### PR DESCRIPTION
- Update `@wordpress/env` from `11.11.0` to `11.12.0`.
- Refresh the dependency lockfile.
- Update the transitive `brace-expansion` dependency from `2.1.2` to `2.1.4`.

